### PR TITLE
Update demos to Python3, PEP 8 standard

### DIFF
--- a/demos/colors/colortest.py
+++ b/demos/colors/colortest.py
@@ -1,6 +1,6 @@
-#Copyright ReportLab Europe Ltd. 2000-2008
-#see license.txt for license details
-__version__='''$Id: colortest.py 3269 2008-09-03 17:22:41Z rgbecker $'''
+# Copyright ReportLab Europe Ltd. 2000-2008
+# see license.txt for license details
+__version__ = '''$Id: colortest.py 3269 2008-09-03 17:22:41Z rgbecker $'''
 import reportlab.pdfgen.canvas
 from reportlab.lib import colors
 from reportlab.lib.units import inch
@@ -9,65 +9,64 @@ from reportlab.lib.units import inch
 def run():
     c = reportlab.pdfgen.canvas.Canvas('colortest.pdf')
 
-    #do a test of CMYK interspersed with RGB
+    # do a test of CMYK interspersed with RGB
 
-    #first do RGB values
-    framePage(c, 'Color Demo - RGB Space and CMYK spaces interspersed' )
+    # first do RGB values
+    framePage(c, 'Color Demo - RGB Space and CMYK spaces interspersed')
 
     y = 700
 
-    c.setFillColorRGB(0,0,0)
+    c.setFillColorRGB(0, 0, 0)
     c.drawString(100, y, 'cyan')
-    c.setFillColorCMYK(1,0,0,0)
+    c.setFillColorCMYK(1, 0, 0, 0)
     c.rect(200, y, 300, 30, fill=1)
     y = y - 40
 
-    c.setFillColorRGB(0,0,0)
+    c.setFillColorRGB(0, 0, 0)
     c.drawString(100, y, 'red')
-    c.setFillColorRGB(1,0,0)
+    c.setFillColorRGB(1, 0, 0)
     c.rect(200, y, 300, 30, fill=1)
     y = y - 40
 
-    c.setFillColorRGB(0,0,0)
+    c.setFillColorRGB(0, 0, 0)
     c.drawString(100, y, 'magenta')
-    c.setFillColorCMYK(0,1,0,0)
+    c.setFillColorCMYK(0, 1, 0, 0)
     c.rect(200, y, 300, 30, fill=1)
     y = y - 40
 
-    c.setFillColorRGB(0,0,0)
+    c.setFillColorRGB(0, 0, 0)
     c.drawString(100, y, 'green')
-    c.setFillColorRGB(0,1,0)
+    c.setFillColorRGB(0, 1, 0)
     c.rect(200, y, 300, 30, fill=1)
     y = y - 40
 
-    c.setFillColorRGB(0,0,0)
+    c.setFillColorRGB(0, 0, 0)
     c.drawString(100, y, 'yellow')
-    c.setFillColorCMYK(0,0,1,0)
+    c.setFillColorCMYK(0, 0, 1, 0)
     c.rect(200, y, 300, 30, fill=1)
     y = y - 40
 
-    c.setFillColorRGB(0,0,0)
+    c.setFillColorRGB(0, 0, 0)
     c.drawString(100, y, 'blue')
-    c.setFillColorRGB(0,0,1)
+    c.setFillColorRGB(0, 0, 1)
     c.rect(200, y, 300, 30, fill=1)
     y = y - 40
 
-    c.setFillColorRGB(0,0,0)
+    c.setFillColorRGB(0, 0, 0)
     c.drawString(100, y, 'black')
-    c.setFillColorCMYK(0,0,0,1)
+    c.setFillColorCMYK(0, 0, 0, 1)
     c.rect(200, y, 300, 30, fill=1)
     y = y - 40
-
 
     c.showPage()
 
-    #do all named colors
+    # do all named colors
     framePage(c, 'Color Demo - RGB Space - page %d' % c.getPageNumber())
 
     all_colors = reportlab.lib.colors.getAllNamedColors().items()
-    all_colors.sort() # alpha order by name
+    all_colors.sort()  # alpha order by name
     c.setFont('Times-Roman', 12)
-    c.drawString(72,730, 'This shows all the named colors in the HTML standard.')
+    c.drawString(72, 730, 'This shows all the named colors in the HTML standard.')
     y = 700
     for (name, color) in all_colors:
         c.setFillColor(colors.black)
@@ -80,26 +79,25 @@ def run():
             framePage(c, 'Color Demo - RGB Space - page %d' % c.getPageNumber())
             y = 700
 
-
-
-
     c.save()
 
+
 def framePage(canvas, title):
-    canvas.setFont('Times-BoldItalic',20)
+    canvas.setFont('Times-BoldItalic', 20)
     canvas.drawString(inch, 10.5 * inch, title)
 
-    canvas.setFont('Times-Roman',10)
+    canvas.setFont('Times-Roman', 10)
     canvas.drawCentredString(4.135 * inch, 0.75 * inch,
-                            'Page %d' % canvas.getPageNumber())
+                             'Page %d' % canvas.getPageNumber())
 
-    #draw a border
-    canvas.setStrokeColorRGB(1,0,0)
+    # draw a border
+    canvas.setStrokeColorRGB(1, 0, 0)
     canvas.setLineWidth(5)
     canvas.line(0.8 * inch, inch, 0.8 * inch, 10.75 * inch)
-    #reset carefully afterwards
+    # reset carefully afterwards
     canvas.setLineWidth(1)
-    canvas.setStrokeColorRGB(0,0,0)
+    canvas.setStrokeColorRGB(0, 0, 0)
+
 
 if __name__ == '__main__':
     run()

--- a/demos/colors/colortest.py
+++ b/demos/colors/colortest.py
@@ -64,7 +64,8 @@ def run():
     framePage(c, 'Color Demo - RGB Space - page %d' % c.getPageNumber())
 
     all_colors = reportlab.lib.colors.getAllNamedColors().items()
-    all_colors.sort()  # alpha order by name
+
+    list(all_colors).sort(key=lambda c: c[0])  # alpha order by name
     c.setFont('Times-Roman', 12)
     c.drawString(72, 730, 'This shows all the named colors in the HTML standard.')
     y = 700

--- a/demos/gadflypaper/gfe.py
+++ b/demos/gadflypaper/gfe.py
@@ -1,14 +1,17 @@
-#Copyright ReportLab Europe Ltd. 2000-2008
-#see license.txt for license details
-__doc__=''
-__version__=''' $Id: gfe.py 3269 2008-09-03 17:22:41Z rgbecker $ '''
+# Copyright ReportLab Europe Ltd. 2000-2008
+# see license.txt for license details
+__doc__ = ''
+__version__ = ''' $Id: gfe.py 3269 2008-09-03 17:22:41Z rgbecker $ '''
 
-#REPORTLAB_TEST_SCRIPT
+# REPORTLAB_TEST_SCRIPT
 import sys
-from reportlab.platypus import *
+from reportlab.platypus import (Spacer, SimpleDocTemplate, Paragraph, Preformatted,
+                                PageBreak)
 from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.lib.units import inch
 from reportlab.rl_config import defaultPageSize
-PAGE_HEIGHT=defaultPageSize[1]
+
+PAGE_HEIGHT = defaultPageSize[1]
 
 styles = getSampleStyleSheet()
 
@@ -30,39 +33,43 @@ can add functionality to the engine such as alternative disk based
 indexed table implementations, dynamic interfaces to remote data
 bases or or other data sources, and user defined computations."""
 
-from reportlab.lib.units import inch
 
 pageinfo = "%s / %s / %s" % (Author, email, Title)
 
+
 def myFirstPage(canvas, doc):
     canvas.saveState()
-    #canvas.setStrokeColorRGB(1,0,0)
-    #canvas.setLineWidth(5)
-    #canvas.line(66,72,66,PAGE_HEIGHT-72)
-    canvas.setFont('Times-Bold',16)
+    # canvas.setStrokeColorRGB(1,0,0)
+    # canvas.setLineWidth(5)
+    # canvas.line(66,72,66,PAGE_HEIGHT-72)
+    canvas.setFont('Times-Bold', 16)
     canvas.drawString(108, PAGE_HEIGHT-108, Title)
-    canvas.setFont('Times-Roman',9)
+    canvas.setFont('Times-Roman', 9)
     canvas.drawString(inch, 0.75 * inch, "First Page / %s" % pageinfo)
     canvas.restoreState()
 
+
 def myLaterPages(canvas, doc):
-    #canvas.drawImage("snkanim.gif", 36, 36)
+    # canvas.drawImage("snkanim.gif", 36, 36)
     canvas.saveState()
-    #canvas.setStrokeColorRGB(1,0,0)
-    #canvas.setLineWidth(5)
-    #canvas.line(66,72,66,PAGE_HEIGHT-72)
-    canvas.setFont('Times-Roman',9)
+    # canvas.setStrokeColorRGB(1,0,0)
+    # canvas.setLineWidth(5)
+    # canvas.line(66,72,66,PAGE_HEIGHT-72)
+    canvas.setFont('Times-Roman', 9)
     canvas.drawString(inch, 0.75 * inch, "Page %d %s" % (doc.page, pageinfo))
     canvas.restoreState()
 
+
 def go():
-    Elements.insert(0,Spacer(0,inch))
+    Elements.insert(0, Spacer(0, inch))
     doc = SimpleDocTemplate('gfe.pdf')
-    doc.build(Elements,onFirstPage=myFirstPage, onLaterPages=myLaterPages)
+    doc.build(Elements, onFirstPage=myFirstPage, onLaterPages=myLaterPages)
+
 
 Elements = []
 
-HeaderStyle = styles["Heading1"] # XXXX
+HeaderStyle = styles["Heading1"]  # XXXX
+
 
 def header(txt, style=HeaderStyle, klass=Paragraph, sep=0.3):
     s = Spacer(0.2*inch, sep*inch)
@@ -70,14 +77,18 @@ def header(txt, style=HeaderStyle, klass=Paragraph, sep=0.3):
     para = klass(txt, style)
     Elements.append(para)
 
+
 ParaStyle = styles["Normal"]
+
 
 def p(txt):
     return header(txt, style=ParaStyle, sep=0.1)
 
-#pre = p # XXX
+# pre = p # XXX
+
 
 PreStyle = styles["Code"]
+
 
 def pre(txt):
     s = Spacer(0.1*inch, 0.1*inch)
@@ -85,7 +96,8 @@ def pre(txt):
     p = Preformatted(txt, PreStyle)
     Elements.append(p)
 
-#header(Title, sep=0.1. style=ParaStyle)
+
+# header(Title, sep=0.1. style=ParaStyle)
 header(Author, sep=0.1, style=ParaStyle)
 header(URL, sep=0.1, style=ParaStyle)
 header(email, sep=0.1, style=ParaStyle)
@@ -272,8 +284,8 @@ and like at least two beers not served by lolas
 """)
 
 if 0:
-   go()
-   sys.exit(1)
+    go()
+    sys.exit(1)
 
 pre("""
     select f.drinker
@@ -348,8 +360,6 @@ a later release. This paper also does not intend to explain
 the complete operations of the internals; it is intended to provide
 at least enough information to understand the basic mechanisms
 for extending gadfly.""")
-
-
 
 
 p("""Some concepts and definitions provided next help with the description
@@ -447,7 +457,8 @@ pre("""
 p("""Illustrating that remapping using the [DRINKER&lt;=DRINKER,
 BAR&lt;=BAR] graph eliminates all attributes except DRINKER and
 BAR, such as BEER. More generally remap can be used in this way
-to implement the classical relational projection operation. (See [Korth and Silberschatz]
+to implement the classical relational projection operation.
+(See [Korth and Silberschatz]
 for a detailed discussion of the projection operator and other relational
 algebra operators such as selection, rename, difference and joins.)""")
 
@@ -846,7 +857,8 @@ that generally programmers should focus first on obtaining a working
 implementation (because as John Ousterhout is reported to have
 said "the biggest performance improvement is the transition
 from non-working to working") using the methodology that
-is most likely to obtain a working solution the quickest (Python). Only then if the performance
+is most likely to obtain a working solution the quickest (Python).
+Only then if the performance
 is inadequate should the programmer focus on optimizing
 the inner most loops, perhaps moving them to a very efficient
 implementation (C). Optimizing the outer loops will buy little

--- a/demos/odyssey/dodyssey.py
+++ b/demos/odyssey/dodyssey.py
@@ -1,24 +1,28 @@
-#Copyright ReportLab Europe Ltd. 2000-2008
-#see license.txt for license details
-__version__=''' $Id: dodyssey.py 3660 2010-02-08 18:17:33Z damian $ '''
-__doc__=''
+# Copyright ReportLab Europe Ltd. 2000-2008
+# see license.txt for license details
+__version__ = ''' $Id: dodyssey.py 3660 2010-02-08 18:17:33Z damian $ '''
+__doc__ = ''
 
-#REPORTLAB_TEST_SCRIPT
-import sys, copy, os
-from reportlab.platypus import *
-_NEW_PARA=os.environ.get('NEW_PARA','0')[0] in ('y','Y','1')
-_REDCAP=int(os.environ.get('REDCAP','0'))
-_CALLBACK=os.environ.get('CALLBACK','0')[0] in ('y','Y','1')
-if _NEW_PARA:
-    def Paragraph(s,style):
-        from rlextra.radxml.para import Paragraph as PPPP
-        return PPPP(s,style)
-
+# REPORTLAB_TEST_SCRIPT
+import sys
+import copy
+import os
 from reportlab.lib.units import inch
 from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.lib.enums import TA_LEFT, TA_RIGHT, TA_CENTER, TA_JUSTIFY
-
 import reportlab.rl_config
+from reportlab.platypus import (BaseDocTemplate, Frame, PageTemplate, PageBreak,
+                                NextPageTemplate, Spacer, Preformatted, Paragraph)
+
+_NEW_PARA = os.environ.get('NEW_PARA', '0')[0] in ('y', 'Y', '1')
+_REDCAP = int(os.environ.get('REDCAP', '0'))
+_CALLBACK = os.environ.get('CALLBACK', '0')[0] in ('y', 'Y', '1')
+if _NEW_PARA:
+    def Paragraph(s, style):  # noqa: F811
+        from rlextra.radxml.para import Paragraph as PPPP
+        return PPPP(s, style)
+
+
 reportlab.rl_config.invariant = 1
 
 styles = getSampleStyleSheet()
@@ -26,38 +30,44 @@ styles = getSampleStyleSheet()
 Title = "The Odyssey"
 Author = "Homer"
 
+
 def myTitlePage(canvas, doc):
     canvas.saveState()
     canvas.restoreState()
 
+
 def myLaterPages(canvas, doc):
     canvas.saveState()
-    canvas.setFont('Times-Roman',9)
+    canvas.setFont('Times-Roman', 9)
     canvas.drawString(inch, 0.75 * inch, "Page %d" % doc.page)
     canvas.restoreState()
 
+
 def go():
-    def myCanvasMaker(fn,**kw):
+    def myCanvasMaker(fn, **kw):
         from reportlab.pdfgen.canvas import Canvas
-        canv = Canvas(fn,**kw)
+        canv = Canvas(fn, **kw)
         # attach our callback to the canvas
         canv.myOnDrawCB = myOnDrawCB
         return canv
 
-    doc = BaseDocTemplate('dodyssey.pdf',showBoundary=0)
+    doc = BaseDocTemplate('dodyssey.pdf', showBoundary=0)
 
-    #normal frame as for SimpleFlowDocument
+    # normal frame as for SimpleFlowDocument
     frameT = Frame(doc.leftMargin, doc.bottomMargin, doc.width, doc.height, id='normal')
 
-    #Two Columns
-    frame1 = Frame(doc.leftMargin, doc.bottomMargin, doc.width/2-6, doc.height, id='col1')
+    # Two Columns
+    frame1 = Frame(doc.leftMargin, doc.bottomMargin,
+                   doc.width/2-6, doc.height, id='col1')
     frame2 = Frame(doc.leftMargin+doc.width/2+6, doc.bottomMargin, doc.width/2-6,
-                        doc.height, id='col2')
-    doc.addPageTemplates([PageTemplate(id='First',frames=frameT, onPage=myTitlePage),
-                        PageTemplate(id='OneCol',frames=frameT, onPage=myLaterPages),
-                        PageTemplate(id='TwoCol',frames=[frame1,frame2], onPage=myLaterPages),
-                        ])
-    doc.build(Elements,canvasmaker=myCanvasMaker)
+                   doc.height, id='col2')
+    doc.addPageTemplates([PageTemplate(id='First', frames=frameT, onPage=myTitlePage),
+                          PageTemplate(id='OneCol', frames=frameT, onPage=myLaterPages),
+                          PageTemplate(id='TwoCol', frames=[frame1, frame2],
+                                       onPage=myLaterPages),
+                          ])
+    doc.build(Elements, canvasmaker=myCanvasMaker)
+
 
 Elements = []
 
@@ -69,12 +79,18 @@ InitialStyle.fontsize = 16
 InitialStyle.leading = 20
 PreStyle = styles["Code"]
 
+
 def newPage():
     Elements.append(PageBreak())
 
+
 chNum = 0
-def myOnDrawCB(canv,kind,label):
-    print 'myOnDrawCB(%s)'%kind, 'Page number=', canv.getPageNumber(), 'label value=', label
+
+
+def myOnDrawCB(canv, kind, label):
+    print('myOnDrawCB(%s)' % kind, 'Page number=', canv.getPageNumber(),
+          'label value=', label)
+
 
 def chapter(txt, style=ChapterStyle):
     global chNum
@@ -84,13 +100,16 @@ def chapter(txt, style=ChapterStyle):
     if _NEW_PARA or not _CALLBACK:
         Elements.append(Paragraph(txt, style))
     else:
-        Elements.append(Paragraph(('foo<onDraw name="myOnDrawCB" label="chap %d"/> '%chNum)+txt, style))
+        Elements.append(Paragraph(('foo<onDraw name="myOnDrawCB" label="chap %d"/> ' %
+                                   chNum)+txt, style))
     Elements.append(Spacer(0.2*inch, 0.3*inch))
     if useTwoCol:
         Elements.append(NextPageTemplate('TwoCol'))
 
-def fTitle(txt,style=InitialStyle):
+
+def fTitle(txt, style=InitialStyle):
     Elements.append(Paragraph(txt, style))
+
 
 ParaStyle = copy.deepcopy(styles["Normal"])
 ParaStyle.spaceBefore = 0.1*inch
@@ -106,33 +125,41 @@ else:
     ParaStyle.alignment = TA_JUSTIFY
 
 useTwoCol = 'notwocol' not in sys.argv
+
+
 def spacer(inches):
     Elements.append(Spacer(0.1*inch, inches*inch))
+
 
 def p(txt, style=ParaStyle):
     if _REDCAP:
         fs, fe = '<font color="red" size="+2">', '</font>'
         n = len(txt)
-        for i in xrange(n):
-            if 'a'<=txt[i]<='z' or 'A'<=txt[i]<='Z':
+        for i in range(n):
+            if 'a' <= txt[i] <= 'z' or 'A' <= txt[i] <= 'Z':
                 txt = (txt[:i]+(fs+txt[i]+fe))+txt[i+1:]
                 break
-        if _REDCAP>=2 and n>20:
+        if _REDCAP >= 2 and n > 20:
             j = i+len(fs)+len(fe)+1+int((n-1)/2)
-            while not ('a'<=txt[j]<='z' or 'A'<=txt[j]<='Z'): j += 1
-            txt = (txt[:j]+('<b><i><font size="+2" color="blue">'+txt[j]+'</font></i></b>'))+txt[j+1:]
+            while not ('a' <= txt[j] <= 'z' or 'A' <= txt[j] <= 'Z'):
+                j += 1
+            txt = (txt[:j] + ('<b><i><font size="+2" color="blue">' + txt[j] +
+                              '</font></i></b>'))+txt[j+1:]
 
-        if _REDCAP==3 and n>20:
+        if _REDCAP == 3 and n > 20:
             n = len(txt)
             fs = '<font color="green" size="+1">'
-            for i in xrange(n-1,-1,-1):
-                if 'a'<=txt[i]<='z' or 'A'<=txt[i]<='Z':
-                    txt = txt[:i]+((fs+txt[i]+fe)+txt[i+1:])
+            for i in range(n-1, -1, -1):
+                if 'a' <= txt[i] <= 'z' or 'A' <= txt[i] <= 'Z':
+                    txt = txt[:i] + ((fs+txt[i]+fe) + txt[i+1:])
                     break
 
     Elements.append(Paragraph(txt, style))
 
+
 firstPre = 1
+
+
 def pre(txt, style=PreStyle):
     global firstPre
     if firstPre:
@@ -144,102 +171,115 @@ def pre(txt, style=PreStyle):
     p = Preformatted(txt, style)
     Elements.append(p)
 
+
 def parseOdyssey(fn):
     from time import time
     E = []
-    t0=time()
-    text = open(fn,'r').read()
+    t0 = time()
+    text = open(fn, 'r').read()
     i0 = text.index('Book I')
     endMarker = 'covenant of peace between the two contending parties.'
     i1 = text.index(endMarker)+len(endMarker)
-    PREAMBLE=map(str.strip,text[0:i0].split('\n'))
-    L=map(str.strip,text[i0:i1].split('\n'))
-    POSTAMBLE=map(str.strip,text[i1:].split('\n'))
+    PREAMBLE = [s.strip() for s in text[0:i0].split('\n')]
+    L = [s.strip() for s in text[i0:i1].split('\n')]
+    POSTAMBLE = [s.strip() for s in text[i1:].split('\n')]
 
     def ambleText(L):
-        while L and not L[0]: L.pop(0)
+        while L and not L[0]:
+            L.pop(0)
         while L:
-            T=[]
+            T = []
             while L and L[0]:
                 T.append(L.pop(0))
             yield T
-            while L and not L[0]: L.pop(0)
+            while L and not L[0]:
+                L.pop(0)
 
     def mainText(L):
         while L:
             B = L.pop(0)
-            while not L[0]: L.pop(0)
-            T=[]
+            while not L[0]:
+                L.pop(0)
+            T = []
             while L and L[0]:
                 T.append(L.pop(0))
-            while not L[0]: L.pop(0)
+            while not L[0]:
+                L.pop(0)
             P = []
-            while L and not (L[0].startswith('Book ') and len(L[0].split())==2):
-                E=[]
+            while L and not (L[0].startswith('Book ') and len(L[0].split()) == 2):
+                E = []
                 while L and L[0]:
                     E.append(L.pop(0))
                 P.append(E)
                 if L:
-                    while not L[0]: L.pop(0)
-            yield B,T,P
+                    while not L[0]:
+                        L.pop(0)
+            yield B, T, P
 
     t1 = time()
-    print "open(%s,'r').read() took %.4f seconds" %(fn,t1-t0)
+    print("open(%s, 'r').read() took %.4f seconds" % (fn, t1-t0))
 
-    E.append([spacer,2])
-    E.append([fTitle,'<font color="red">%s</font>' % Title, InitialStyle])
-    E.append([fTitle,'<font size="-4">by</font> <font color="green">%s</font>' % Author, InitialStyle])
+    E.append([spacer, 2])
+    E.append([fTitle, '<font color="red">%s</font>' % Title, InitialStyle])
+    E.append([fTitle, '<font size="-4">by</font> <font color="green">%s</font>' %
+              Author, InitialStyle])
 
     for T in ambleText(PREAMBLE):
-        E.append([p,'\n'.join(T)])
+        E.append([p, '\n'.join(T)])
 
-    for (B,T,P) in mainText(L):
-        E.append([chapter,B])
-        E.append([p,'<font size="+1" color="Blue"><b>%s</b></font>' % '\n'.join(T),ParaStyle])
+    for (B, T, P) in mainText(L):
+        E.append([chapter, B])
+        E.append([p, '<font size="+1" color="Blue"><b>%s</b></font>' % '\n'.join(T),
+                  ParaStyle])
         for x in P:
-            E.append([p,' '.join(x)])
-    firstPre = 1
+            E.append([p, ' '.join(x)])
+    # firstPre = 1  assigned but not used
     for T in ambleText(POSTAMBLE):
-        E.append([p,'\n'.join(T)])
+        E.append([p, '\n'.join(T)])
 
     t3 = time()
-    print "Parsing into memory took %.4f seconds" %(t3-t1)
+    print("Parsing into memory took %.4f seconds" % (t3-t1))
     del L
     t4 = time()
-    print "Deleting list of lines took %.4f seconds" %(t4-t3)
-    for i in xrange(len(E)):
+    print("Deleting list of lines took %.4f seconds" % (t4-t3))
+    for i in range(len(E)):
         E[i][0](*E[i][1:])
     t5 = time()
-    print "Moving into platypus took %.4f seconds" %(t5-t4)
+    print("Moving into platypus took %.4f seconds" % (t5-t4))
     del E
     t6 = time()
-    print "Deleting list of actions took %.4f seconds" %(t6-t5)
+    print("Deleting list of actions took %.4f seconds" % (t6-t5))
     go()
     t7 = time()
-    print "saving to PDF took %.4f seconds" %(t7-t6)
-    print "Total run took %.4f seconds"%(t7-t0)
+    print("saving to PDF took %.4f seconds" % (t7-t6))
+    print("Total run took %.4f seconds" % (t7-t0))
 
-    import md5
-    print 'file digest: %s' % md5.md5(open('dodyssey.pdf','rb').read()).hexdigest()
+    import hashlib
+    print('file digest: %s' % hashlib.md5(open('dodyssey.pdf', 'rb')
+                                          .read()).hexdigest())
+
 
 def run():
-    for fn in ('odyssey.full.txt','odyssey.txt'):
+    for fn in ('odyssey.full.txt', 'odyssey.txt'):
         if os.path.isfile(fn):
             parseOdyssey(fn)
             break
 
-def doProf(profname,func,*args,**kwd):
-        import hotshot, hotshot.stats
-        prof = hotshot.Profile(profname)
-        prof.runcall(func)
-        prof.close()
-        stats = hotshot.stats.load(profname)
-        stats.strip_dirs()
-        stats.sort_stats('time', 'calls')
-        stats.print_stats(20)
 
-if __name__=='__main__':
+def doProf(profname, func, *args, **kwd):
+    import hotshot
+    import hotshot.stats
+    prof = hotshot.Profile(profname)
+    prof.runcall(func)
+    prof.close()
+    stats = hotshot.stats.load(profname)
+    stats.strip_dirs()
+    stats.sort_stats('time', 'calls')
+    stats.print_stats(20)
+
+
+if __name__ == '__main__':
     if '--prof' in sys.argv:
-        doProf('dodyssey.prof',run)
+        doProf('dodyssey.prof', run)
     else:
         run()

--- a/demos/odyssey/fodyssey.py
+++ b/demos/odyssey/fodyssey.py
@@ -1,11 +1,14 @@
-#Copyright ReportLab Europe Ltd. 2000-2008
-#see license.txt for license details
-__version__=''' $Id: fodyssey.py 3660 2010-02-08 18:17:33Z damian $ '''
-__doc__=''
+# Copyright ReportLab Europe Ltd. 2000-2008
+# see license.txt for license details
+__version__ = ''' $Id: fodyssey.py 3660 2010-02-08 18:17:33Z damian $ '''
+__doc__ = ''
 
-#REPORTLAB_TEST_SCRIPT
-import sys, copy, os
-from reportlab.platypus import *
+# REPORTLAB_TEST_SCRIPT
+import sys
+import copy
+import os
+from reportlab.platypus import (SimpleDocTemplate, PageBreak, Paragraph, Spacer,
+                                Preformatted)
 from reportlab.lib.units import inch
 from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.lib.enums import TA_LEFT, TA_RIGHT, TA_CENTER, TA_JUSTIFY
@@ -18,20 +21,24 @@ styles = getSampleStyleSheet()
 Title = "The Odyssey"
 Author = "Homer"
 
+
 def myFirstPage(canvas, doc):
     canvas.saveState()
     canvas.restoreState()
 
+
 def myLaterPages(canvas, doc):
     canvas.saveState()
-    canvas.setFont('Times-Roman',9)
+    canvas.setFont('Times-Roman', 9)
     canvas.drawString(inch, 0.75 * inch, "Page %d" % doc.page)
     canvas.restoreState()
 
+
 def go():
-    doc = SimpleDocTemplate('fodyssey.pdf',showBoundary='showboundary' in sys.argv)
-    doc.allowSplitting = not 'nosplitting' in sys.argv
-    doc.build(Elements,myFirstPage,myLaterPages)
+    doc = SimpleDocTemplate('fodyssey.pdf', showBoundary='showboundary' in sys.argv)
+    doc.allowSplitting = 'nosplitting' not in sys.argv
+    doc.build(Elements, myFirstPage, myLaterPages)
+
 
 Elements = []
 
@@ -43,16 +50,20 @@ InitialStyle.fontsize = 16
 InitialStyle.leading = 20
 PreStyle = styles["Code"]
 
+
 def newPage():
     Elements.append(PageBreak())
+
 
 def chapter(txt, style=ChapterStyle):
     newPage()
     Elements.append(Paragraph(txt, style))
     Elements.append(Spacer(0.2*inch, 0.3*inch))
 
-def fTitle(txt,style=InitialStyle):
+
+def fTitle(txt, style=InitialStyle):
     Elements.append(Paragraph(txt, style))
+
 
 ParaStyle = copy.deepcopy(styles["Normal"])
 ParaStyle.spaceBefore = 0.1*inch
@@ -67,94 +78,108 @@ elif 'center' in sys.argv or 'centre' in sys.argv:
 else:
     ParaStyle.alignment = TA_JUSTIFY
 
+
 def spacer(inches):
     Elements.append(Spacer(0.1*inch, inches*inch))
 
+
 def p(txt, style=ParaStyle):
     Elements.append(Paragraph(txt, style))
+
 
 def pre(txt, style=PreStyle):
     spacer(0.1)
     p = Preformatted(txt, style)
     Elements.append(p)
 
+
 def parseOdyssey(fn):
     from time import time
     E = []
-    t0=time()
-    text = open(fn,'r').read()
+    t0 = time()
+    text = open(fn, 'r').read()
     i0 = text.index('Book I')
     endMarker = 'covenant of peace between the two contending parties.'
     i1 = text.index(endMarker)+len(endMarker)
-    PREAMBLE=map(str.strip,text[0:i0].split('\n'))
-    L=map(str.strip,text[i0:i1].split('\n'))
-    POSTAMBLE=map(str.strip,text[i1:].split('\n'))
+    # map object doesn't support indexing, replace with list comprehensions
+    PREAMBLE = [s.strip() for s in text[0:i0].split('\n')]
+    L = [s.strip() for s in text[i0:i1].split('\n')]
+    POSTAMBLE = [s.strip() for s in text[i1:].split('\n')]
 
     def ambleText(L):
-        while L and not L[0]: L.pop(0)
+        while L and not L[0]:
+            L.pop(0)
         while L:
-            T=[]
+            T = []
             while L and L[0]:
                 T.append(L.pop(0))
             yield T
-            while L and not L[0]: L.pop(0)
+            while L and not L[0]:
+                L.pop(0)
 
     def mainText(L):
         while L:
             B = L.pop(0)
-            while not L[0]: L.pop(0)
-            T=[]
+            while not L[0]:
+                L.pop(0)
+            T = []
             while L and L[0]:
                 T.append(L.pop(0))
-            while not L[0]: L.pop(0)
+            while not L[0]:
+                L.pop(0)
             P = []
-            while L and not (L[0].startswith('Book ') and len(L[0].split())==2):
-                E=[]
+            while L and not (L[0].startswith('Book ') and len(L[0].split()) == 2):
+                E = []
                 while L and L[0]:
                     E.append(L.pop(0))
                 P.append(E)
                 if L:
-                    while not L[0]: L.pop(0)
-            yield B,T,P
+                    while not L[0]:
+                        L.pop(0)
+            yield B, T, P
 
     t1 = time()
-    print "open(%s,'r').read() took %.4f seconds" %(fn,t1-t0)
+    print("open(%s, 'r').read() took %.4f seconds" % (fn, t1 - t0))
 
-    E.append([spacer,2])
-    E.append([fTitle,'<font color=red>%s</font>' % Title, InitialStyle])
-    E.append([fTitle,'<font size=-4>by</font> <font color=green>%s</font>' % Author, InitialStyle])
+    E.append([spacer, 2])
+    E.append([fTitle, '<font color=red>%s</font>' % Title, InitialStyle])
+    E.append([fTitle, '<font size=-4>by</font> <font color=green>%s</font>' % Author,
+              InitialStyle])
 
     for T in ambleText(PREAMBLE):
-        E.append([p,'\n'.join(T)])
+        E.append([p, '\n'.join(T)])
 
-    for (B,T,P) in mainText(L):
-        E.append([chapter,B])
-        E.append([p,'<font size="+1" color="Blue"><b>%s</b></font>' % '\n'.join(T),ParaStyle])
+    for (B, T, P) in mainText(L):
+        E.append([chapter, B])
+        E.append([p, '<font size="+1" color="Blue"><b>%s</b></font>' % '\n'.join(T),
+                  ParaStyle])
         for x in P:
-            E.append([p,' '.join(x)])
-    firstPre = 1
+            E.append([p, ' '.join(x)])
+    # firstPre = 1 (assigned but not used)
     for T in ambleText(POSTAMBLE):
-        E.append([p,'\n'.join(T)])
+        E.append([p, '\n'.join(T)])
 
     t3 = time()
-    print "Parsing into memory took %.4f seconds" %(t3-t1)
+    print("Parsing into memory took %.4f seconds" % (t3-t1))
     del L
     t4 = time()
-    print "Deleting list of lines took %.4f seconds" %(t4-t3)
-    for i in xrange(len(E)):
+    print("Deleting list of lines took %.4f seconds" % (t4-t3))
+    for i in range(len(E)):  # no xrange in Python 3, but range gives desired behavior
         E[i][0](*E[i][1:])
     t5 = time()
-    print "Moving into platypus took %.4f seconds" %(t5-t4)
+    print("Moving into platypus took %.4f seconds" % (t5-t4))
     del E
     t6 = time()
-    print "Deleting list of actions took %.4f seconds" %(t6-t5)
+    print("Deleting list of actions took %.4f seconds" % (t6-t5))
     go()
     t7 = time()
-    print "saving to PDF took %.4f seconds" %(t7-t6)
-    print "Total run took %.4f seconds"%(t7-t0)
+    print("saving to PDF took %.4f seconds" % (t7-t6))
+    print("Total run took %.4f seconds" % (t7-t0))
 
-for fn in ('odyssey.full.txt','odyssey.txt'):
+
+for fn in ('odyssey.full.txt', 'odyssey.txt'):
     if os.path.isfile(fn):
         break
-if __name__=='__main__':
+
+if __name__ == '__main__':
     parseOdyssey(fn)

--- a/demos/odyssey/odyssey.py
+++ b/demos/odyssey/odyssey.py
@@ -1,14 +1,11 @@
-#Copyright ReportLab Europe Ltd. 2000-2008
-#see license.txt for license details
-__version__=''' $Id: odyssey.py 3271 2008-09-04 12:45:58Z rgbecker $ '''
-___doc__=''
-#odyssey.py
+# Copyright ReportLab Europe Ltd. 2000-2008
+# see license.txt for license details
+__version__ = ''' $Id: odyssey.py 3271 2008-09-04 12:45:58Z rgbecker $ '''
+___doc__ = ''
+# odyssey.py
 #
-#Demo/benchmark of PDFgen rendering Homer's Odyssey.
-
-
-
-#results on my humble P266 with 64MB:
+# Demo/benchmark of PDFgen rendering Homer's Odyssey.
+# results on my humble P266 with 64MB:
 # Without page compression:
 # 239 pages in 3.76 seconds = 77 pages per second
 
@@ -20,23 +17,23 @@ ___doc__=''
 # 239 pages in 39.39 seconds = 6 pages per second
 
 from reportlab.pdfgen import canvas
-import time, os, sys
+import time
+import os
+import sys
 
-#find out what platform we are on and whether accelerator is
-#present, in order to print this as part of benchmark info.
+# find out what platform we are on and whether accelerator is
+# present, in order to print this as part of benchmark info.
 try:
-    import _rl_accel
+    import _rl_accel  # noqa: F401
     ACCEL = 1
 except ImportError:
     ACCEL = 0
 
 
-
-
-from reportlab.lib.units import inch, cm
+from reportlab.lib.units import inch
 from reportlab.lib.pagesizes import A4
 
-#precalculate some basics
+# precalculate some basics
 top_margin = A4[1] - inch
 bottom_margin = inch
 left_margin = inch
@@ -46,15 +43,13 @@ frame_width = right_margin - left_margin
 
 def drawPageFrame(canv):
     canv.line(left_margin, top_margin, right_margin, top_margin)
-    canv.setFont('Times-Italic',12)
+    canv.setFont('Times-Italic', 12)
     canv.drawString(left_margin, top_margin + 2, "Homer's Odyssey")
     canv.line(left_margin, top_margin, right_margin, top_margin)
 
-
     canv.line(left_margin, bottom_margin, right_margin, bottom_margin)
     canv.drawCentredString(0.5*A4[0], 0.5 * inch,
-               "Page %d" % canv.getPageNumber())
-
+                           "Page %d" % canv.getPageNumber())
 
 
 def run(verbose=1):
@@ -67,14 +62,14 @@ def run(verbose=1):
         accelStr = 'with _rl_accel'
     else:
         accelStr = 'without _rl_accel'
-    print 'Benchmark of %s %s %s' % (impl, verStr, accelStr)
+    print('Benchmark of %s %s %s' % (impl, verStr, accelStr))
 
     started = time.time()
     canv = canvas.Canvas('odyssey.pdf', invariant=1)
     canv.setPageCompression(1)
     drawPageFrame(canv)
 
-    #do some title page stuff
+    # do some title page stuff
     canv.setFont("Times-Bold", 36)
     canv.drawCentredString(0.5 * A4[0], 7 * inch, "Homer's Odyssey")
 
@@ -83,32 +78,36 @@ def run(verbose=1):
 
     canv.setFont("Times-Bold", 12)
     tx = canv.beginText(left_margin, 3 * inch)
-    tx.textLine("This is a demo-cum-benchmark for PDFgen.  It renders the complete text of Homer's Odyssey")
-    tx.textLine("from a text file.  On my humble P266, it does 77 pages per secondwhile creating a 238 page")
-    tx.textLine("document.  If it is asked to computer text metrics, measuring the width of each word as ")
-    tx.textLine("one would for paragraph wrapping, it still manages 22 pages per second.")
+    tx.textLine("This is a demo-cum-benchmark for PDFgen. " +
+                " It renders the complete text of Homer's Odyssey")
+    tx.textLine("from a text file.  On my humble P266, it does " +
+                "77 pages per secondwhile creating a 238 page")
+    tx.textLine("document.  If it is asked to computer text metrics, " +
+                "measuring the width of each word as ")
+    tx.textLine("one would for paragraph wrapping, " +
+                "it still manages 22 pages per second.")
     tx.textLine("")
     tx.textLine("Andy Robinson, Robinson Analytics Ltd.")
     canv.drawText(tx)
 
     canv.showPage()
-    #on with the text...
+    # on with the text...
     drawPageFrame(canv)
 
     canv.setFont('Times-Roman', 12)
     tx = canv.beginText(left_margin, top_margin - 0.5*inch)
 
-    for fn in ('odyssey.full.txt','odyssey.txt'):
+    for fn in ('odyssey.full.txt', 'odyssey.txt'):
         if os.path.isfile(fn):
             break
 
-    data = open(fn,'r').readlines()
+    data = open(fn, 'r').readlines()
     for line in data:
-        #this just does it the fast way...
+        # this just does it the fast way...
         tx.textLine(line.rstrip())
 
-        #page breaking
-        y = tx.getY()   #get y coordinate
+        # page breaking
+        y = tx.getY()   # get y coordinate
         if y < bottom_margin + 0.5*inch:
             canv.drawText(tx)
             canv.showPage()
@@ -116,10 +115,10 @@ def run(verbose=1):
             canv.setFont('Times-Roman', 12)
             tx = canv.beginText(left_margin, top_margin - 0.5*inch)
 
-            #page
+            # page
             pg = canv.getPageNumber()
             if verbose and pg % 10 == 0:
-                print 'formatted page %d' % canv.getPageNumber()
+                print('formatted page %d' % canv.getPageNumber())
 
     if tx:
         canv.drawText(tx)
@@ -127,20 +126,21 @@ def run(verbose=1):
         drawPageFrame(canv)
 
     if verbose:
-        print 'about to write to disk...'
+        print('about to write to disk...')
 
     canv.save()
 
     finished = time.time()
     elapsed = finished - started
     pages = canv.getPageNumber()-1
-    speed =  pages / elapsed
+    speed = pages / elapsed
     fileSize = os.stat('odyssey.pdf')[6] / 1024
-    print '%d pages in %0.2f seconds = %0.2f pages per second, file size %d kb' % (
-                pages, elapsed, speed, fileSize)
+    print('%d pages in %0.2f seconds = %0.2f pages per second, file size %d kb' % (
+                pages, elapsed, speed, fileSize))
     import md5
-    print 'file digest: %s' % md5.md5(open('odyssey.pdf','rb').read()).hexdigest()
+    print('file digest: %s' % md5.md5(open('odyssey.pdf', 'rb').read()).hexdigest())
 
-if __name__=='__main__':
+
+if __name__ == '__main__':
     quiet = ('-q' in sys.argv)
-    run(verbose = not quiet)
+    run(verbose=not quiet)

--- a/demos/odyssey/odyssey.py
+++ b/demos/odyssey/odyssey.py
@@ -137,8 +137,8 @@ def run(verbose=1):
     fileSize = os.stat('odyssey.pdf')[6] / 1024
     print('%d pages in %0.2f seconds = %0.2f pages per second, file size %d kb' % (
                 pages, elapsed, speed, fileSize))
-    import md5
-    print('file digest: %s' % md5.md5(open('odyssey.pdf', 'rb').read()).hexdigest())
+    import hashlib
+    print('file digest: %s' % hashlib.md5(open('odyssey.pdf', 'rb').read()).hexdigest())
 
 
 if __name__ == '__main__':

--- a/demos/stdfonts/stdfonts.py
+++ b/demos/stdfonts/stdfonts.py
@@ -1,6 +1,6 @@
-#Copyright ReportLab Europe Ltd. 2000-2008
-#see license.txt for license details
-__doc__="""
+# Copyright ReportLab Europe Ltd. 2000-2008
+# see license.txt for license details
+__doc__ = """
 This generates tables showing the 14 standard fonts in both
 WinAnsi and MacRoman encodings, and their character codes.
 Supply an argument of 'hex' or 'oct' to get code charts
@@ -9,15 +9,16 @@ sequences in Python literals.
 
 usage: standardfonts.py [dec|hex|oct]
 """
-__version__=''' $Id: stdfonts.py 3269 2008-09-03 17:22:41Z rgbecker $ '''
+__version__ = ''' $Id: stdfonts.py 3269 2008-09-03 17:22:41Z rgbecker $ '''
 import sys
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfgen import canvas
 import string
 
-label_formats = {'dec':('%d=', 'Decimal'),
-                 'oct':('%o=','Octal'),
-                 'hex':('0x%x=', 'Hexadecimal')}
+label_formats = {'dec': ('%d=', 'Decimal'),
+                 'oct': ('%o=', 'Octal'),
+                 'hex': ('0x%x=', 'Hexadecimal')}
+
 
 def run(mode):
 
@@ -36,19 +37,15 @@ def run(mode):
                 encLabel = enc + 'Encoding'
 
             fontName = faceName + '-' + encLabel
-            pdfmetrics.registerFont(pdfmetrics.Font(fontName,
-                                        faceName,
-                                        encLabel)
-                        )
+            pdfmetrics.registerFont(pdfmetrics.Font(fontName, faceName, encLabel))
 
             canv.setFont('Times-Bold', 18)
             canv.drawString(80, 744, fontName)
             canv.setFont('Times-BoldItalic', 12)
             canv.drawRightString(515, 744, 'Labels in ' + caption)
 
-
-            #for dingbats, we need to use another font for the numbers.
-            #do two parallel text objects.
+            # for dingbats, we need to use another font for the numbers.
+            # do two parallel text objects.
             for byt in range(32, 256):
                 col, row = divmod(byt - 32, 32)
                 x = 72 + (66*col)
@@ -56,18 +53,22 @@ def run(mode):
                 canv.setFont('Helvetica', 14)
                 canv.drawString(x, y, label_formatter % byt)
                 canv.setFont(fontName, 14)
-                canv.drawString(x+44, y, chr(byt).decode(encLabel,'ignore').encode('utf8'))
+                # str object has no attribute decode
+                # canv.drawString(x+44, y, chr(byt).decode(encLabel,
+                #                                          'ignore').encode('utf8'))
+                canv.drawString(x+44, y, chr(byt).encode('utf8'))
             canv.showPage()
         canv.save()
 
+
 if __name__ == '__main__':
-    if len(sys.argv)==2:
+    if len(sys.argv) == 2:
         mode = string.lower(sys.argv[1])
-        if mode not in ['dec','oct','hex']:
-            print __doc__
+        if mode not in ['dec', 'oct', 'hex']:
+            print(__doc__)
 
     elif len(sys.argv) == 1:
         mode = 'dec'
         run(mode)
     else:
-        print __doc__
+        print(__doc__)

--- a/demos/tests/testdemos.py
+++ b/demos/tests/testdemos.py
@@ -1,13 +1,18 @@
 #!/bin/env python
-#Copyright ReportLab Europe Ltd. 2000-2008
-#see license.txt for license details
-__doc__='Test all demos'
-__version__=''' $Id: testdemos.py 3269 2008-09-03 17:22:41Z rgbecker $ '''
-_globals=globals().copy()
-import os, sys
+# Copyright ReportLab Europe Ltd. 2000-2008
+# see license.txt for license details
+import os
 from reportlab import pdfgen
 
-for p in ('pythonpoint/pythonpoint.py','stdfonts/stdfonts.py','odyssey/odyssey.py', 'gadflypaper/gfe.py'):
-    fn = os.path.normcase(os.path.normpath(os.path.join(os.path.dirname(pdfgen.__file__),'..','demos',p)))
+__doc__ = 'Test all demos'
+__version__ = ''' $Id: testdemos.py 3269 2008-09-03 17:22:41Z rgbecker $ '''
+_globals = globals().copy()
+
+for p in ('pythonpoint/pythonpoint.py', 'stdfonts/stdfonts.py', 'odyssey/odyssey.py',
+          'gadflypaper/gfe.py'):
+    fn = os.path.normcase(os.path.normpath(os.path.join(
+        os.path.dirname(pdfgen.__file__), '..', 'demos', p)))
     os.chdir(os.path.dirname(fn))
-    execfile(fn,_globals.copy())
+    with open(fn, 'r') as f:
+        os.exec(f, _globals.copy())
+    # execfile(fn, _globals.copy())  (no execfile in Python 3)


### PR DESCRIPTION
The demo script `reportlab/demos/stdfonts.py` is mentioned in Chapter 2 of the User Guide.  It wasn't in the Pip installed package, but I found the demos in the repository.  It seems that most of the demo scripts were written for Python 2.  I updated to Python 3 as well as I could, and tried to bring the formatting to the PEP 8 standard.

Best,
Dow